### PR TITLE
Correct capitalization of Arduino.h include filename

### DIFF
--- a/Sha/sha1_config.h
+++ b/Sha/sha1_config.h
@@ -10,7 +10,7 @@
 	#include <sys/time.h>
 	#include <unistd.h>
 #else
-	#include "arduino.h"
+	#include "Arduino.h"
 #endif
 
 #if  (defined(__linux) || defined(linux)) || defined(__ARDUINO_X86__)

--- a/Sha/sha256_config.h
+++ b/Sha/sha256_config.h
@@ -11,7 +11,7 @@
         #include <sys/time.h>
         #include <unistd.h>
 #else
-        #include "arduino.h"
+        #include "Arduino.h"
 #endif
 
 #if  (defined(__linux) || defined(linux)) || defined(__ARDUINO_X86__)


### PR DESCRIPTION
The correct filename is Arduino.h. Incorrect capitalization is not an issue on filename case insensitive operating systems such as Windows but on filename case sensitive operating systems such as Linux the previous incorrect filename will cause compilation to fail.